### PR TITLE
It is now possible to list users for sudo access.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This role installs sudo package, ensure that /etc/sudoers.d included and
 create or remove sudoers files in /etc/sudoers.d.
-For now, each user has full sudo access, and global setting determines whether
+For now, each sudoer has access to all commands within a variable set of users, and global setting determines whether
 NOPASSWD is set or not.
 
 ## Variables
@@ -11,6 +11,8 @@ NOPASSWD is set or not.
  * sudoers - A list of users who have sudo access. Use '%foo' to specify that
    users in a given group have sudo access.
    * defaults: []
+ * sudoers_users - A list of users the sudoers can impersonate.
+   * defaults: ["ALL"]
  * sudoers_nopasswd - if set, NOPASSWD is added to all sudoers entries. Use this
    when users don't have passwords set.
    * default: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,14 @@
 ---
-apt_cache_valid_time: 3600
+sudoers_apt_cache_valid_time: 3600
 
 # Who has sudo access - use %foo for groups
 sudoers: []
 
 # Do users need to enter a password?
 sudoers_nopasswd: true
+
+# What users can sudoers impersonate?
+sudoers_users: ["ALL"]
 
 # Remove file from /etc/sudoers.d?
 sudoers_remove: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install sudo (Debian-like)
-  apt: pkg=sudo state=installed update_cache=yes cache_valid_time={{ apt_cache_valid_time }}
+  apt: pkg=sudo state=installed update_cache=yes cache_valid_time={{ sudoers_apt_cache_valid_time }}
   when: ansible_os_family == "Debian"
 
 - name: Install sudo (RedHat-like)

--- a/templates/sudoers.d.j2
+++ b/templates/sudoers.d.j2
@@ -1,4 +1,4 @@
 # {{ ansible_managed }}
-{% for i in sudoers %}
-{{i}} ALL=(ALL) {% if sudoers_nopasswd %}NOPASSWD: {% endif %}ALL
+{% for sudoer in sudoers %}
+{{ sudoer }} ALL=({{ sudoers_users | join(',') }}) {% if sudoers_nopasswd %}NOPASSWD: {% endif %}ALL
 {% endfor %}


### PR DESCRIPTION
templates/sudoers.d.j2 and defaults/main.yml:
- Added sudoers_users, which is an array that contains the users
  that the sudoers can access to. Defaults to ALL to keep the actual
  behaviour.

README.md:
- Decription of sudoers_users.

tasks/main.yml:
- Changed apt_cache_valid_time to sudoers_apt_cache_valid_time to
  avoid collisions with other roles/playbooks.
